### PR TITLE
Fix time series chart layout when header wraps to two lines

### DIFF
--- a/src/components/data_viz/TimeSeriesChart/TimeSeriesChart-styled.js
+++ b/src/components/data_viz/TimeSeriesChart/TimeSeriesChart-styled.js
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 import { CalciteP, CalciteH6 } from 'calcite-react/Elements';
 
+const StyledTimeSeriesContainer = styled.div`
+  flex: 1 0 0;
+`;
+
 const StyledTimeSeries = styled.div`
   display: flex;
   flex-direction: column;
@@ -22,9 +26,11 @@ const StyledChartSection = styled.div`
 `;
 
 const StyledChart = styled.div`
-  flex: 1 0 auto;
+  flex: 1 0 0;
   height: 224px;
   padding-left: 10px;
+  display: flex;
+  flex-direction: column;
 `;
 
 const StyledCrosshairTooltip = styled.div`
@@ -52,6 +58,7 @@ const StyledChartHeader = styled(CalciteH6)`
 `;
 
 export {
+  StyledTimeSeriesContainer,
   StyledTimeSeries,
   StyledDescriptionContainer,
   StyledDescriptionText,

--- a/src/components/data_viz/TimeSeriesChart/TimeSeriesChart.js
+++ b/src/components/data_viz/TimeSeriesChart/TimeSeriesChart.js
@@ -10,7 +10,8 @@ import {
   StyledCrosshairTooltip,
   StyledCrosshairLabel,
   StyledCrosshairValue,
-  StyledChartHeader
+  StyledChartHeader,
+  StyledTimeSeriesContainer
 } from './TimeSeriesChart-styled';
 
 import SeriesLinks from '../../SeriesLinks';
@@ -136,50 +137,52 @@ class TimeSeriesChart extends Component {
 
   getTimeSeriesChart = ({ series, goalInfo }) => {
     return (
-      <AutoSizer>
-        {({ width }) => (
-          <XYPlot
-            animation={{ duration: 5000 }}
-            xType="time"
-            yDomain={this.getYDomain(
-              this.state.dataIsUniform,
-              this.state.sortedData
-            )}
-            width={width - 10}
-            height={200}
-            yPadding={30}
-            xPadding={20}
-            onMouseLeave={() => this._onNearestX(null)}
-          >
-            {this.getZeroLine(this.state.dataRange)}
-            <LineMarkSeries
-              data={this.state.sortedData}
-              curve={'curveMonotoneX'}
-              color={goalInfo.colorInfo.hex}
-              markStyle={{ fill: 'white', strokeWidth: 2 }}
-              onNearestX={datapoint => this._onNearestX(datapoint)}
-            />
-            <XAxis tickTotal={this.getXTickTotal(this.state.sortedData)} />
-            <YAxis />
-            {this.state.crossHairValue ? (
-              <Crosshair values={[this.state.crossHairValue]}>
-                <StyledCrosshairTooltip>
-                  <StyledCrosshairLabel>
-                    {this.state.crossHairValue.x.toLocaleString('en-us', {
-                      year: 'numeric'
-                    })}
-                    :
-                  </StyledCrosshairLabel>
-                  <StyledCrosshairValue>
-                    {this.state.crossHairValue.t}
-                    {series.fact_units[0]}
-                  </StyledCrosshairValue>
-                </StyledCrosshairTooltip>
-              </Crosshair>
-            ) : null}
-          </XYPlot>
-        )}
-      </AutoSizer>
+      <StyledTimeSeriesContainer>
+        <AutoSizer>
+          {({ width, height }) => (
+            <XYPlot
+              animation={{ duration: 5000 }}
+              xType="time"
+              yDomain={this.getYDomain(
+                this.state.dataIsUniform,
+                this.state.sortedData
+              )}
+              width={width - 10}
+              height={height}
+              yPadding={30}
+              xPadding={20}
+              onMouseLeave={() => this._onNearestX(null)}
+            >
+              {this.getZeroLine(this.state.dataRange)}
+              <LineMarkSeries
+                data={this.state.sortedData}
+                curve={'curveMonotoneX'}
+                color={goalInfo.colorInfo.hex}
+                markStyle={{ fill: 'white', strokeWidth: 2 }}
+                onNearestX={datapoint => this._onNearestX(datapoint)}
+              />
+              <XAxis tickTotal={this.getXTickTotal(this.state.sortedData)} />
+              <YAxis />
+              {this.state.crossHairValue ? (
+                <Crosshair values={[this.state.crossHairValue]}>
+                  <StyledCrosshairTooltip>
+                    <StyledCrosshairLabel>
+                      {this.state.crossHairValue.x.toLocaleString('en-us', {
+                        year: 'numeric'
+                      })}
+                      :
+                    </StyledCrosshairLabel>
+                    <StyledCrosshairValue>
+                      {this.state.crossHairValue.t}
+                      {series.fact_units[0]}
+                    </StyledCrosshairValue>
+                  </StyledCrosshairTooltip>
+                </Crosshair>
+              ) : null}
+            </XYPlot>
+          )}
+        </AutoSizer>
+      </StyledTimeSeriesContainer>
     );
   };
 


### PR DESCRIPTION
- Fixes chart sizing when header wraps to two lines.

Let me know if this should go into `master` instead.